### PR TITLE
Use compiler intrinsic to calculate mask

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(teakra
     ahbm.h
     apbp.cpp
     apbp.h
+    bit.h
     btdmp.cpp
     btdmp.h
     common_types.h

--- a/src/bit.h
+++ b/src/bit.h
@@ -1,0 +1,48 @@
+// This file is under the public domain.
+
+#pragma once
+
+#include <cstddef>
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+#include "common_types.h"
+
+namespace Common {
+
+#ifdef _MSC_VER
+inline u8 MostSignificantSetBit(u8 val) {
+    unsigned long index;
+    _BitScanReverse(&index, val);
+    return static_cast<u8>(index);
+}
+inline u8 MostSignificantSetBit(u16 val) {
+    unsigned long index;
+    _BitScanReverse(&index, val);
+    return static_cast<u8>(index);
+}
+inline u8 MostSignificantSetBit(u32 val) {
+    unsigned long index;
+    _BitScanReverse(&index, val);
+    return static_cast<u8>(index);
+}
+inline u8 MostSignificantSetBit(u64 val) {
+    unsigned long index;
+    _BitScanReverse64(&index, val);
+    return static_cast<u8>(index);
+}
+#else
+inline u8 MostSignificantSetBit(u8 val) {
+    return static_cast<u8>(sizeof(unsigned int) * 8 - __builtin_clz(val) - 1);
+}
+inline u8 MostSignificantSetBit(u16 val) {
+    return static_cast<u8>(sizeof(unsigned int) * 8 - __builtin_clz(val) - 1);
+}
+inline u8 MostSignificantSetBit(u32 val) {
+    return static_cast<u8>(sizeof(unsigned int) * 8 - __builtin_clz(val) - 1);
+}
+inline u8 MostSignificantSetBit(u64 val) {
+    return static_cast<u8>(sizeof(unsigned long long) * 8 - __builtin_clzll(val) - 1);
+}
+#endif
+} // namespace Common

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -4,6 +4,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
+#include "bit.h"
 #include "core_timing.h"
 #include "crash.h"
 #include "decoder.h"
@@ -3518,11 +3519,8 @@ private:
                         m |= s;
                     }
 
-                    u16 mask = 0;
-                    for (unsigned i = 0; i < 9; ++i) {
-                        mask |= m >> i;
-                    }
-
+                    // mod can't be zero so we don't need to worry about handling that edgecase
+                    u16 mask = (1 << (Common::MostSignificantSetBit(m) + 1)) - 1;
                     u16 next;
                     if (!negative) {
                         if ((address & mask) == mod && (!step2_mode2 || mod != mask)) {
@@ -3540,11 +3538,8 @@ private:
                     address &= ~mask;
                     address |= next;
                 } else {
-                    u16 mask = 0;
-                    for (unsigned i = 0; i < 9; ++i) {
-                        mask |= mod >> i;
-                    }
-
+                    // mod can't be zero so we don't need to worry about handling that edgecase
+                    u16 mask = (1 << (Common::MostSignificantSetBit(mod) + 1)) - 1;
                     u16 next;
                     if (s < 0x8000) {
                         next = (address + s) & mask;


### PR DESCRIPTION
Profiling showed that the naive caluclation of the bit mask was rather
hot. The mask is just the first 2^n-1 larger than mod, which means an
intrinsic that uses BSR on intel would be much faster. This shaves off
around 5ms frametime when running the Pokemon X intro

Also adds a missing include to fix msvc compiling.

(I didn't test compiling on non msvc so please wait for CI to check them)