### PR TITLE
Integrate accuracy test into CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ Thumbs.db
 
 teakra.out
 teakra.out.*
+
+# cmake and ctest temporary files
+/Testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ matrix:
       os: linux
       dist: xenial
       sudo: false
+      cache:
+        directories:
+          - $HOME/assets
       addons:
         apt:
           sources:
@@ -18,7 +21,13 @@ matrix:
       os: osx
       sudo: false
       osx_image: xcode10
+      cache:
+        directories:
+          - $HOME/assets
       script: ./.travis/macos-build.sh
     - env: NAME="Windows Build"
       os: windows
+      cache:
+        directories:
+          - $HOME/assets
       script: ./.travis/windows-build.sh

--- a/.travis/linux-build.sh
+++ b/.travis/linux-build.sh
@@ -7,6 +7,6 @@ export CC=gcc-7
 export CXX=g++-7
 
 mkdir build && cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake .. -DCMAKE_BUILD_TYPE=Release -DTEAKRA_TEST_ASSETS_DIR="$HOME/assets" -DTEAKRA_RUN_TESTS=ON
 cmake --build . -- -j"$(nproc)"
-ctest
+ctest -C Release

--- a/.travis/macos-build.sh
+++ b/.travis/macos-build.sh
@@ -8,5 +8,5 @@ export MACOSX_DEPLOYMENT_TARGET=10.14
 
 mkdir build && cd build
 cmake .. -GXcode -DCMAKE_BUILD_TYPE=Release
-xcodebuild -configuration Release
+xcodebuild -configuration Release -jobs "$(nproc)"
 ctest

--- a/.travis/macos-build.sh
+++ b/.travis/macos-build.sh
@@ -7,6 +7,6 @@ set -o pipefail
 export MACOSX_DEPLOYMENT_TARGET=10.14
 
 mkdir build && cd build
-cmake .. -GXcode -DCMAKE_BUILD_TYPE=Release
-xcodebuild -configuration Release -jobs "$(nproc)"
-ctest
+cmake .. -GXcode -DCMAKE_BUILD_TYPE=Release -DTEAKRA_TEST_ASSETS_DIR="$HOME/assets" -DTEAKRA_RUN_TESTS=ON
+xcodebuild -configuration Release -jobs 2
+ctest -C Release

--- a/.travis/windows-build.sh
+++ b/.travis/windows-build.sh
@@ -5,6 +5,6 @@ set -x
 
 
 mkdir build && cd build
-cmake .. -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=Release
+cmake .. -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=Release -DTEAKRA_TEST_ASSETS_DIR="$HOME/assets" -DTEAKRA_RUN_TESTS=OFF
 cmake --build . -- -maxcpucount
-ctest
+# ctest -C Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 
 option(TEAKRA_WARNINGS_AS_ERRORS "Warnings as errors" ${MASTER_PROJECT})
 option(TEAKRA_BUILD_TOOLS "Build tools" ${MASTER_PROJECT})
+option(TEAKRA_RUN_TESTS "Run Teakra accuracy tests" OFF)
 
 # Set hard requirements for C++
 set(CMAKE_CXX_STANDARD 17)
@@ -69,5 +70,10 @@ endif()
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
+enable_testing()
+
+if (NOT TEAKRA_TEST_ASSETS_DIR)
+  set(TEAKRA_TEST_ASSETS_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+endif()
 # Teakra project files
 add_subdirectory(src)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,11 @@ install:
 before_build:
   - mkdir build
   - cd build
-  - cmake .. -G "%cmake_generator%"
+  - cmake .. -G "%cmake_generator%" -DTEAKRA_TEST_ASSETS_DIR="%USERPROFILE%\assets" -DTEAKRA_RUN_TESTS=ON
   - cd ..
+
+cache:
+  - '%USERPROFILE%\assets'
 
 build:
   project: build/teakra.sln

--- a/src/test_verifier/CMakeLists.txt
+++ b/src/test_verifier/CMakeLists.txt
@@ -7,3 +7,30 @@ create_target_directory_groups(test_verifier)
 target_link_libraries(test_verifier PRIVATE teakra)
 target_include_directories(test_verifier PRIVATE .)
 target_compile_options(test_verifier PRIVATE ${TEAKRA_CXX_FLAGS})
+
+
+# Test related stuff
+set(ASSET_SHA256SUM "baffcd4f805a7480d969401792443a34aa39f813b4f0ae49c6365f1d1f3ce120")
+if(TEAKRA_RUN_TESTS)
+  message(STATUS "Will run Teakra accuracy tests")
+  # download fixtures if there is none
+  if(NOT EXISTS "${TEAKRA_TEST_ASSETS_DIR}/teaklite2_tests_result")
+    message(STATUS "Downloading required samples...")
+    file(DOWNLOAD
+      "https://liushuyu.b-cdn.net/teaklite2_tests_result_20181208"
+      "${TEAKRA_TEST_ASSETS_DIR}/teaklite2_tests_result"
+      EXPECTED_HASH SHA256=${ASSET_SHA256SUM}
+      SHOW_PROGRESS
+  )
+  else()
+    # check if provided fixtures are good
+    file(SHA256 "${TEAKRA_TEST_ASSETS_DIR}/teaklite2_tests_result" ASSET_CHECKSUM)
+    if(ASSET_SHA256SUM STREQUAL ASSET_CHECKSUM)
+      message(STATUS "Unit test sample looks good.")
+    else()
+      message(FATAL_ERROR "Unit test sample broken. Please remove the file and re-run CMake.")
+    endif()
+  endif()
+endif(TEAKRA_RUN_TESTS)
+
+add_test(NAME tests COMMAND test_verifier "${TEAKRA_TEST_ASSETS_DIR}/teaklite2_tests_result")

--- a/src/test_verifier/CMakeLists.txt
+++ b/src/test_verifier/CMakeLists.txt
@@ -31,6 +31,6 @@ if(TEAKRA_RUN_TESTS)
       message(FATAL_ERROR "Unit test sample broken. Please remove the file and re-run CMake.")
     endif()
   endif()
-endif(TEAKRA_RUN_TESTS)
 
-add_test(NAME tests COMMAND test_verifier "${TEAKRA_TEST_ASSETS_DIR}/teaklite2_tests_result")
+  add_test(NAME tests COMMAND test_verifier "${TEAKRA_TEST_ASSETS_DIR}/teaklite2_tests_result")
+endif(TEAKRA_RUN_TESTS)

--- a/src/test_verifier/main.cpp
+++ b/src/test_verifier/main.cpp
@@ -254,4 +254,11 @@ int main(int argc, char** argv) {
     std::printf("%d / %d passed, %d skipped\n", passed, total, skipped);
 
     std::fclose(file);
+
+    if (passed < total) {
+      return 1;
+    }
+
+    return 0;
+
 }


### PR DESCRIPTION
In this PR, HW LLE accuracy test is included in CI checks.

Currently, due to a bug in Travis CI Windows agent, the test on that platform is disabled.

_____

And I think there will be some work to do if you want to use Catch2 Unit Test Framework. It does not provide "skip" method, and you need to sub-class the `Matcher` to make it outputs the useful information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wwylele/teakra/15)
<!-- Reviewable:end -->
