### PR TITLE
test_verifier: speed up testing process

### DIFF
--- a/src/test_verifier/main.cpp
+++ b/src/test_verifier/main.cpp
@@ -122,6 +122,13 @@ int main(int argc, char** argv) {
                 }
             };
 
+            auto CheckAddress = [&](const char* name, u16 address, u16 expected, u16 actual) {
+                if (expected != actual) {
+                    std::printf("Mismatch: %s%s: %04X != %04X\n", name, (ToHex<u16>(address)).c_str(), expected, actual);
+                    pass = false;
+                }
+            };
+
             auto CheckFlag = [&](const char* name, u16 expected, u16 actual, const char* symbols) {
                 if (expected != actual) {
                     std::printf("Mismatch: %s: %s != %s\n", name,
@@ -171,10 +178,10 @@ int main(int argc, char** argv) {
             CheckFlag("arp3", test_case.after.arp[3], regs.Get<Teakra::arp3>(), "#RR#RRjjjjjiiiii");
 
             for (u16 offset = 0; offset < TestSpaceSize; ++offset) {
-                Check(("memory_" + ToHex<u16>(TestSpaceX + offset)).c_str(),
+                CheckAddress("memory_", (TestSpaceX + offset),
                       test_case.after.test_space_x[offset],
                       memory_interface.DataRead(TestSpaceX + offset));
-                Check(("memory_" + ToHex<u16>(TestSpaceY + offset)).c_str(),
+                CheckAddress("memory_", (TestSpaceY + offset),
                       test_case.after.test_space_y[offset],
                       memory_interface.DataRead(TestSpaceY + offset));
             }

--- a/src/test_verifier/main.cpp
+++ b/src/test_verifier/main.cpp
@@ -25,13 +25,6 @@ std::string Flag16ToString(u16 value, const char* symbols) {
     return result;
 }
 
-template <typename T>
-std::string ToHex(T i) {
-    u64 v = i;
-    std::stringstream stream;
-    stream << "0x" << std::setfill('0') << std::setw(sizeof(T) * 2) << std::hex << v;
-    return stream.str();
-}
 
 int main(int argc, char** argv) {
     if (argc < 2)
@@ -124,7 +117,7 @@ int main(int argc, char** argv) {
 
             auto CheckAddress = [&](const char* name, u16 address, u16 expected, u16 actual) {
                 if (expected != actual) {
-                    std::printf("Mismatch: %s%s: %04X != %04X\n", name, (ToHex<u16>(address)).c_str(), expected, actual);
+                    std::printf("Mismatch: %s%04X: %04X != %04X\n", name, address, expected, actual);
                     pass = false;
                 }
             };


### PR DESCRIPTION
speed up the testing process by not calling `ToHex` so often as `ToHex` is very expensive to call.

In this PR, I added a new check type, so the `ToHex` call only happens when the target test is failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wwylele/teakra/16)
<!-- Reviewable:end -->
