### PR TITLE
Mark member functions const where applicable

### DIFF
--- a/include/teakra/teakra.h
+++ b/include/teakra/teakra.h
@@ -4,7 +4,6 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <vector>
 
 namespace Teakra {
 
@@ -33,7 +32,7 @@ public:
     // APBP Semaphore
     void SetSemaphore(std::uint16_t value);
     void SetSemaphoreHandler(std::function<void()> handler);
-    std::uint16_t GetSemaphore();
+    std::uint16_t GetSemaphore() const;
 
     // core
     void Run(unsigned cycle);

--- a/src/ahbm.cpp
+++ b/src/ahbm.cpp
@@ -147,7 +147,7 @@ void Ahbm::WriteInternal(u16 channel, u32 address, u32 value) {
     }
 }
 
-u16 Ahbm::GetChannelForDma(u16 dma_channel) {
+u16 Ahbm::GetChannelForDma(u16 dma_channel) const {
     for (u16 channel = 0; channel < channels.size(); ++channel) {
         if ((channels[channel].dma_channel >> dma_channel) & 1) {
             return channel;

--- a/src/ahbm.h
+++ b/src/ahbm.h
@@ -28,31 +28,31 @@ public:
 
     void Reset();
 
-    u16 GetBusyFlag() {
+    u16 GetBusyFlag() const {
         return busy_flag;
     }
     void SetUnitSize(u16 i, u16 value) {
         channels[i].unit_size = static_cast<UnitSize>(value);
     }
-    u16 GetUnitSize(u16 i) {
+    u16 GetUnitSize(u16 i) const {
         return static_cast<u16>(channels[i].unit_size);
     }
     void SetBurstSize(u16 i, u16 value) {
         channels[i].burst_size = static_cast<BurstSize>(value);
     }
-    u16 GetBurstSize(u16 i) {
+    u16 GetBurstSize(u16 i) const {
         return static_cast<u16>(channels[i].burst_size);
     }
     void SetDirection(u16 i, u16 value) {
         channels[i].direction = static_cast<Direction>(value);
     }
-    u16 GetDirection(u16 i) {
+    u16 GetDirection(u16 i) const {
         return static_cast<u16>(channels[i].direction);
     }
     void SetDmaChannel(u16 i, u16 value) {
         channels[i].dma_channel = value;
     }
-    u16 GetDmaChannel(u16 i) {
+    u16 GetDmaChannel(u16 i) const {
         return channels[i].dma_channel;
     }
 
@@ -61,7 +61,7 @@ public:
     void Write16(u16 channel, u32 address, u16 value);
     void Write32(u16 channel, u32 address, u32 value);
 
-    u16 GetChannelForDma(u16 dma_channel);
+    u16 GetChannelForDma(u16 dma_channel) const;
 
     void SetExternalMemoryCallback(std::function<u8(u32)> read,
                                    std::function<void(u32, u8)> write) {

--- a/src/apbp.cpp
+++ b/src/apbp.cpp
@@ -108,7 +108,7 @@ void Apbp::SetSemaphoreHandler(std::function<void()> handler) {
     impl->semaphore_handler = std::move(handler);
 }
 
-bool Apbp::IsSemaphoreSignaled() {
+bool Apbp::IsSemaphoreSignaled() const {
     return impl->semaphore_master_signal;
 }
 } // namespace Teakra

--- a/src/apbp.h
+++ b/src/apbp.h
@@ -24,7 +24,7 @@ public:
     u16 GetSemaphoreMask() const;
     void SetSemaphoreHandler(std::function<void()> handler);
 
-    bool IsSemaphoreSignaled();
+    bool IsSemaphoreSignaled() const;
 
 private:
     class Impl;

--- a/src/btdmp.h
+++ b/src/btdmp.h
@@ -20,7 +20,7 @@ public:
         transmit_period = value;
     }
 
-    u16 GetTransmitPeriod() {
+    u16 GetTransmitPeriod() const {
         return transmit_period;
     }
 
@@ -28,15 +28,15 @@ public:
         transmit_enable = value;
     }
 
-    u16 GetTransmitEnable() {
+    u16 GetTransmitEnable() const {
         return transmit_enable;
     }
 
-    u16 GetTransmitEmpty() {
+    u16 GetTransmitEmpty() const {
         return transmit_empty;
     }
 
-    u16 GetTransmitFull() {
+    u16 GetTransmitFull() const {
         return transmit_full;
     }
 
@@ -56,7 +56,7 @@ public:
         transmit_full = false;
     }
 
-    u16 GetTransmitFlush() {
+    u16 GetTransmitFlush() const {
         return 0;
     }
 

--- a/src/dma.h
+++ b/src/dma.h
@@ -3,7 +3,6 @@
 #include <functional>
 #include <utility>
 #include "common_types.h"
-#include "teakra/teakra.h"
 
 namespace Teakra {
 
@@ -19,133 +18,133 @@ public:
     void EnableChannel(u16 value) {
         enable_channel = value;
     }
-    u16 GetChannelEnabled() {
+    u16 GetChannelEnabled() const {
         return enable_channel;
     }
 
     void ActivateChannel(u16 value) {
         active_channel = value;
     }
-    u16 GetActiveChannel() {
+    u16 GetActiveChannel() const {
         return active_channel;
     }
 
     void SetAddrSrcLow(u16 value) {
         channels[active_channel].addr_src_low = value;
     }
-    u16 GetAddrSrcLow() {
+    u16 GetAddrSrcLow() const {
         return channels[active_channel].addr_src_low;
     }
 
     void SetAddrSrcHigh(u16 value) {
         channels[active_channel].addr_src_high = value;
     }
-    u16 GetAddrSrcHigh() {
+    u16 GetAddrSrcHigh() const {
         return channels[active_channel].addr_src_high;
     }
 
     void SetAddrDstLow(u16 value) {
         channels[active_channel].addr_dst_low = value;
     }
-    u16 GetAddrDstLow() {
+    u16 GetAddrDstLow() const {
         return channels[active_channel].addr_dst_low;
     }
 
     void SetAddrDstHigh(u16 value) {
         channels[active_channel].addr_dst_high = value;
     }
-    u16 GetAddrDstHigh() {
+    u16 GetAddrDstHigh() const {
         return channels[active_channel].addr_dst_high;
     }
 
     void SetSize0(u16 value) {
         channels[active_channel].size0 = value;
     }
-    u16 GetSize0() {
+    u16 GetSize0() const {
         return channels[active_channel].size0;
     }
 
     void SetSize1(u16 value) {
         channels[active_channel].size1 = value;
     }
-    u16 GetSize1() {
+    u16 GetSize1() const {
         return channels[active_channel].size1;
     }
 
     void SetSize2(u16 value) {
         channels[active_channel].size2 = value;
     }
-    u16 GetSize2() {
+    u16 GetSize2() const {
         return channels[active_channel].size2;
     }
 
     void SetSrcStep0(u16 value) {
         channels[active_channel].src_step0 = value;
     }
-    u16 GetSrcStep0() {
+    u16 GetSrcStep0() const {
         return channels[active_channel].src_step0;
     }
 
     void SetDstStep0(u16 value) {
         channels[active_channel].dst_step0 = value;
     }
-    u16 GetDstStep0() {
+    u16 GetDstStep0() const {
         return channels[active_channel].dst_step0;
     }
 
     void SetSrcStep1(u16 value) {
         channels[active_channel].src_step1 = value;
     }
-    u16 GetSrcStep1() {
+    u16 GetSrcStep1() const {
         return channels[active_channel].src_step1;
     }
 
     void SetDstStep1(u16 value) {
         channels[active_channel].dst_step1 = value;
     }
-    u16 GetDstStep1() {
+    u16 GetDstStep1() const {
         return channels[active_channel].dst_step1;
     }
 
     void SetSrcStep2(u16 value) {
         channels[active_channel].src_step2 = value;
     }
-    u16 GetSrcStep2() {
+    u16 GetSrcStep2() const {
         return channels[active_channel].src_step2;
     }
 
     void SetDstStep2(u16 value) {
         channels[active_channel].dst_step2 = value;
     }
-    u16 GetDstStep2() {
+    u16 GetDstStep2() const {
         return channels[active_channel].dst_step2;
     }
 
     void SetSrcSpace(u16 value) {
         channels[active_channel].src_space = value;
     }
-    u16 GetSrcSpace() {
+    u16 GetSrcSpace() const {
         return channels[active_channel].src_space;
     }
 
     void SetDstSpace(u16 value) {
         channels[active_channel].dst_space = value;
     }
-    u16 GetDstSpace() {
+    u16 GetDstSpace() const {
         return channels[active_channel].dst_space;
     }
 
     void SetDwordMode(u16 value) {
         channels[active_channel].dword_mode = value;
     }
-    u16 GetDwordMode() {
+    u16 GetDwordMode() const {
         return channels[active_channel].dword_mode;
     }
 
     void SetY(u16 value) {
         channels[active_channel].y = value;
     }
-    u16 GetY() {
+    u16 GetY() const {
         return channels[active_channel].y;
     }
 
@@ -156,7 +155,7 @@ public:
             DoDma(active_channel);
         }
     }
-    u16 GetZ() {
+    u16 GetZ() const {
         return channels[active_channel].z;
     }
 

--- a/src/teakra.cpp
+++ b/src/teakra.cpp
@@ -104,7 +104,7 @@ void Teakra::SetSemaphore(std::uint16_t value) {
 void Teakra::SetSemaphoreHandler(std::function<void()> handler) {
     impl->apbp_from_dsp.SetSemaphoreHandler(handler);
 }
-std::uint16_t Teakra::GetSemaphore() {
+std::uint16_t Teakra::GetSemaphore() const {
     return impl->apbp_from_dsp.GetSemaphore();
 }
 


### PR DESCRIPTION
Fairly self-explanatory. Makes functions that don't modify member state as const.