### PR TITLE
dma/register: Default initialize members where applicable

### DIFF
--- a/src/dma.h
+++ b/src/dma.h
@@ -180,7 +180,7 @@ private:
         u16 src_step1 = 0, dst_step1 = 0;
         u16 src_step2 = 0, dst_step2 = 0;
         u16 src_space = 0, dst_space = 0;
-        u16 dword_mode;
+        u16 dword_mode = 0;
         u16 y = 0;
         u16 z = 0;
 

--- a/src/register.h
+++ b/src/register.h
@@ -57,7 +57,7 @@ struct RegisterState {
 
     // 1-bit flags
     u16 fz = 0, fm = 0, fn = 0, fv = 0, fe = 0;
-    std::array<u16, 2> fc;
+    std::array<u16, 2> fc{};
     u16 flm = 0; // set on saturation
     u16 fvl = 0; // latching fv
     u16 fr = 0;


### PR DESCRIPTION
Makes all members of the relevant structs initialize in a predictable way.