### PR TITLE
test_generator: Remove unused std::random_device instance in GenerateRandomState()

### DIFF
--- a/src/test_generator.cpp
+++ b/src/test_generator.cpp
@@ -86,8 +86,6 @@ struct Config {
     }
 
     State GenerateRandomState() {
-        static std::random_device rd;
-
         State state;
         state.stepi0 = Random::bit16();
         state.stepj0 = Random::bit16();


### PR DESCRIPTION
This is unused, but given it's static (and non-trivial), a compiler cannot remove this instance through dead-code elimination, so this was potentially still opening another file descriptor on the system.