### PR TITLE
decoder: Undefine instruction table macros when done with them

### DIFF
--- a/src/decoder.h
+++ b/src/decoder.h
@@ -684,6 +684,9 @@ std::vector<Matcher<V>> GetDecodeTable() {
 
     INST(addhp, 0x90E0, At<ArRn2, 2>, At<ArStep2, 0>, At<Px, 4>, At<Ax, 8>),
     };
+
+#undef INST
+#undef EXCEPT
 }
 
 // clang-format on


### PR DESCRIPTION
Avoids unintentionally polluting other source files with them.