### PR TITLE
test_generator: Enclose internals within anonymous namespaces, also handle file I/O errors

### DIFF
--- a/src/test.h
+++ b/src/test.h
@@ -1,5 +1,7 @@
 #pragma once
+
 #include <array>
+#include <type_traits>
 
 #ifndef COMMON_TYPE_3DS
 #include "common_types.h"
@@ -25,9 +27,12 @@ struct State {
     std::array<u16, TestSpaceSize> test_space_y;
 };
 
+static_assert(std::is_trivially_copyable_v<State>);
+
 struct TestCase {
     State before, after;
     u16 opcode, expand;
 };
 
 static_assert(sizeof(TestCase) == 4312);
+static_assert(std::is_trivially_copyable_v<TestCase>);

--- a/src/test_generator.cpp
+++ b/src/test_generator.cpp
@@ -19,8 +19,8 @@ enum class ExpandConfig {
 };
 
 namespace Random {
-
-static std::mt19937 gen(std::random_device{}());
+namespace {
+std::mt19937 gen(std::random_device{}());
 
 u64 uniform(u64 a, u64 b) {
     std::uniform_int_distribution<u64> dist(a, b);
@@ -60,9 +60,10 @@ u16 bit16() {
     static std::uniform_int_distribution<u16> dist;
     return dist(gen);
 }
-
+} // Anonymous namespace
 } // namespace Random
 
+namespace {
 struct Config {
     bool enable = false;
     bool lock_page = false;
@@ -1435,6 +1436,7 @@ public:
         return DisabledConfig;
     }
 };
+} // Anonymous namespace
 
 void GenerateTestCasesToFile(const char* path) {
     TestGenerator generator;

--- a/src/test_generator.h
+++ b/src/test_generator.h
@@ -1,5 +1,5 @@
 #pragma once
 
 namespace Teakra::Test {
-void GenerateTestCasesToFile(const char* path);
+bool GenerateTestCasesToFile(const char* path);
 }

--- a/src/test_generator/main.cpp
+++ b/src/test_generator/main.cpp
@@ -1,7 +1,15 @@
+#include <cstdio>
 #include "../test_generator.h"
 
 int main(int argc, char** argv) {
-    if (argc < 2)
+    if (argc < 2) {
         return -1;
-    Teakra::Test::GenerateTestCasesToFile(argv[1]);
+    }
+
+    if (!Teakra::Test::GenerateTestCasesToFile(argv[1])) {
+        std::fprintf(stderr, "Unable to successfully generate all tests.\n");
+        return -2;
+    }
+
+    return 0;
 }


### PR DESCRIPTION
The internals of test_generator.cpp can be given internal linkage, since they aren't used outside of the translation unit.

Also, previously the test generator would potentially crash if a file handle wasn't able to be opened (since it would use a null file pointer in that case).