### PR TITLE
core_timing: Make GetMaxSkip() a const member function

### DIFF
--- a/src/btdmp.cpp
+++ b/src/btdmp.cpp
@@ -11,7 +11,7 @@ public:
         parent.Tick();
     }
 
-    u64 GetMaxSkip() override {
+    u64 GetMaxSkip() const override {
         if (!parent.transmit_enable || parent.transmit_queue.empty()) {
             return Infinity;
         }

--- a/src/core_timing.h
+++ b/src/core_timing.h
@@ -15,7 +15,7 @@ public:
     public:
         virtual ~Callbacks() = default;
         virtual void Tick() = 0;
-        virtual u64 GetMaxSkip() = 0;
+        virtual u64 GetMaxSkip() const = 0;
         virtual void Skip(u64) = 0;
         static constexpr u64 Infinity = std::numeric_limits<u64>::max();
     };

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -10,7 +10,7 @@ public:
         parent.Tick();
     }
 
-    u64 GetMaxSkip() override {
+    u64 GetMaxSkip() const override {
         if (parent.pause || parent.count_mode == CountMode::EventCount)
             return Infinity;
 


### PR DESCRIPTION
Neither of the implementers of this function modify member state, and since it's used as a getter, it can be declared a const member function.