### PR TITLE
test_generator: Amend fwrite check in GenerateTestCasesToFile()

### DIFF
--- a/src/test_generator.cpp
+++ b/src/test_generator.cpp
@@ -1470,7 +1470,7 @@ bool GenerateTestCasesToFile(const char* path) {
                 break;
             }
 
-            if (std::fwrite(&test_case, sizeof(test_case), 1, f.get()) != sizeof(test_case)) {
+            if (std::fwrite(&test_case, sizeof(test_case), 1, f.get()) == 0) {
                 return false;
             }
         }


### PR DESCRIPTION
I mistakenly thought fwrite reported the number of bytes written, not the number of objects.