### PR TITLE
oprand: Mark Rn and Px's constructors as constexpr

### DIFF
--- a/src/oprand.h
+++ b/src/oprand.h
@@ -237,8 +237,8 @@ struct Bxh : RegOprand<
     RegName::b1h
 > {};
 struct Px : Oprand<1> {
-    Px() = default;
-    Px(u16 index) {
+    constexpr Px() = default;
+    constexpr Px(u16 index) {
         this->storage = index;
     }
     constexpr u16 Index() const {
@@ -299,8 +299,8 @@ struct Rn : RegOprand<
     RegName::r6,
     RegName::r7
 > {
-    Rn() = default;
-    Rn(u16 index) {
+    constexpr Rn() = default;
+    constexpr Rn(u16 index) {
         this->storage = index;
     }
     constexpr u16 Index() const {

--- a/src/oprand.h
+++ b/src/oprand.h
@@ -10,7 +10,7 @@ struct Oprand {
     static constexpr unsigned Bits = bits;
 
 protected:
-    u16 storage;
+    u16 storage{};
 
     template <typename OprandT, unsigned pos>
     friend struct At;


### PR DESCRIPTION
It's pretty odd to leave the constructors as non-constexpr, while making any accessor functions constexpr (i.e. Index() can essentially never be used in a truly constexpr scenario, since an instance can't be constructed in a constexpr manner).