### PR TITLE
fix clang-cl error

### DIFF
--- a/src/bit.h
+++ b/src/bit.h
@@ -15,7 +15,7 @@ constexpr T log2p1(T x) noexcept {
     if (x == 0)
         return 0;
 #ifdef _MSC_VER
-    unsigned long index;
+    unsigned long index = 0;
     _BitScanReverse64(&index, x);
     return static_cast<T>(index) + 1;
 #else


### PR DESCRIPTION
```cpp
error : variables defined in a constexpr function must be initialized
      unsigned long index;
                    ^