### PR TITLE
Use <stdexcept> header rather than <exception>

### DIFF
--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <atomic>
-#include <exception>
+#include <stdexcept>
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>


### PR DESCRIPTION
Fixes error C2039: 'runtime_error': is not a member of 'std'

*&lt;exception>* defines only the base `std::exceptionclass`; child classes like `std::runtime_error`, must include the *&lt;stdexcept>* header.
Further explanation can refer [here](https://stackoverflow.com/questions/25163105/stdexcept-vs-exception-headers-in-c) via stackoverflow