### PR TITLE
expose PeekRecvData for DSP_REPx peeking

### DIFF
--- a/include/teakra/teakra.h
+++ b/include/teakra/teakra.h
@@ -27,6 +27,7 @@ public:
     void SendData(std::uint8_t index, std::uint16_t value);
     bool RecvDataIsReady(std::uint8_t index) const;
     std::uint16_t RecvData(std::uint8_t index);
+    std::uint16_t PeekRecvData(std::uint8_t index);
     void SetRecvDataHandler(std::uint8_t index, std::function<void()> handler);
 
     // APBP Semaphore

--- a/include/teakra/teakra_c.h
+++ b/include/teakra/teakra_c.h
@@ -21,6 +21,7 @@ int Teakra_SendDataIsEmpty(const TeakraContext* context, uint8_t index);
 void Teakra_SendData(TeakraContext* context, uint8_t index, uint16_t value);
 int Teakra_RecvDataIsReady(const TeakraContext* context, uint8_t index);
 uint16_t Teakra_RecvData(TeakraContext* context, uint8_t index);
+uint16_t Teakra_PeekRecvData(TeakraContext* context, uint8_t index);
 void Teakra_SetRecvDataHandler(TeakraContext* context, uint8_t index,
                                Teakra_InterruptCallback handler, void* userdata);
 

--- a/src/mod_test_generator/main.cpp
+++ b/src/mod_test_generator/main.cpp
@@ -1,4 +1,5 @@
 #include <cstdio>
+#include <cstdlib>
 #include <memory>
 #include "../test.h"
 
@@ -33,7 +34,7 @@ int main(int argc, char** argv) {
                     test_case.before.ar[0] = (step_mode << 5) | (offset_mode << 8);
                     u16 step_min = 0, step_max = 0x20;
                     if (step_mode != 3) {
-                        step_min = step_max = rand() % 0x20;
+                        step_min = step_max = std::rand() % 0x20;
                         ++step_max;
                     }
                     for (u16 step = step_min; step < step_max; ++step) {

--- a/src/teakra.cpp
+++ b/src/teakra.cpp
@@ -95,6 +95,9 @@ bool Teakra::RecvDataIsReady(std::uint8_t index) const {
 std::uint16_t Teakra::RecvData(std::uint8_t index) {
     return impl->apbp_from_dsp.RecvData(index);
 }
+std::uint16_t Teakra::PeekRecvData(std::uint8_t index) {
+    return impl->apbp_from_dsp.PeekData(index);
+}
 void Teakra::SetRecvDataHandler(std::uint8_t index, std::function<void()> handler) {
     impl->apbp_from_dsp.SetDataHandler(index, std::move(handler));
 }

--- a/src/teakra_c.cpp
+++ b/src/teakra_c.cpp
@@ -38,6 +38,9 @@ int Teakra_RecvDataIsReady(const TeakraContext* context, uint8_t index) {
 uint16_t Teakra_RecvData(TeakraContext* context, uint8_t index) {
     return context->teakra.RecvData(index);
 }
+uint16_t Teakra_PeekRecvData(TeakraContext* context, uint8_t index) {
+    return context->teakra.PeekRecvData(index);
+}
 
 void Teakra_SetRecvDataHandler(TeakraContext* context, uint8_t index,
                                Teakra_InterruptCallback handler, void* userdata) {


### PR DESCRIPTION
As talked about in `#citra-dev`, wanted for melonDS

Also fixes a compile issue in one of the tests