### PR TITLE
Expose program, data and mmio read/write operations, for DSP_PDATA/PADR-based DMA-style transfers

### DIFF
--- a/include/teakra/teakra.h
+++ b/include/teakra/teakra.h
@@ -37,6 +37,21 @@ public:
     void SetSemaphoreHandler(std::function<void()> handler);
     std::uint16_t GetSemaphore() const;
 
+    // for implementing DSP_PDATA/PADR DMA transfers
+    std::uint16_t ProgramRead(std::uint32_t address) const;
+    void ProgramWrite(std::uint32_t address, std::uint16_t value);
+    std::uint16_t DataRead(std::uint16_t address, bool bypass_mmio = false);
+    void DataWrite(std::uint16_t address, std::uint16_t value, bool bypass_mmio = false);
+    std::uint16_t DataReadA32(std::uint32_t address) const;
+    void DataWriteA32(std::uint32_t address, std::uint16_t value);
+    std::uint16_t MMIORead(std::uint16_t address);
+    void MMIOWrite(std::uint16_t address, std::uint16_t value);
+
+    // DSP_PADR is only 16-bit, so this is where the DMA interface gets the
+    // upper 16-bits from
+    std::uint16_t DMAChan0GetSrcHigh();
+    std::uint16_t DMAChan0GetDstHigh();
+
     // core
     void Run(unsigned cycle);
 

--- a/include/teakra/teakra_c.h
+++ b/include/teakra/teakra_c.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,6 +34,18 @@ void Teakra_MaskSemaphore(TeakraContext* context, uint16_t value);
 void Teakra_SetSemaphoreHandler(TeakraContext* context, Teakra_InterruptCallback handler,
                                 void* userdata);
 uint16_t Teakra_GetSemaphore(const TeakraContext* context);
+
+uint16_t Teakra_ProgramRead(TeakraContext* context, uint32_t address);
+void Teakra_ProgramWrite(TeakraContext* context, uint32_t address, uint16_t value);
+uint16_t Teakra_DataRead(TeakraContext* context, uint16_t address, bool bypass_mmio);
+void Teakra_DataWrite(TeakraContext* context, uint16_t address, uint16_t value, bool bypass_mmio);
+uint16_t Teakra_DataReadA32(TeakraContext* context, uint32_t address);
+void Teakra_DataWriteA32(TeakraContext* context, uint32_t address, uint16_t value);
+uint16_t Teakra_MMIORead(TeakraContext* context, uint16_t address);
+void Teakra_MMIOWrite(TeakraContext* context, uint16_t address, uint16_t value);
+
+uint16_t Teakra_DMAChan0GetSrcHigh(TeakraContext* context);
+uint16_t Teakra_DMAChan0GetDstHigh(TeakraContext* context);
 
 void Teakra_Run(TeakraContext* context, unsigned cycle);
 

--- a/src/memory_interface.cpp
+++ b/src/memory_interface.cpp
@@ -17,8 +17,8 @@ u16 MemoryInterface::ProgramRead(u32 address) const {
 void MemoryInterface::ProgramWrite(u32 address, u16 value) {
     shared_memory.WriteWord(address, value);
 }
-u16 MemoryInterface::DataRead(u16 address) {
-    if (memory_interface_unit.InMMIO(address)) {
+u16 MemoryInterface::DataRead(u16 address, bool bypass_mmio) {
+    if (memory_interface_unit.InMMIO(address) && !bypass_mmio) {
         ASSERT(mmio != nullptr);
         return mmio->Read(memory_interface_unit.ToMMIO(address));
     }
@@ -26,13 +26,32 @@ u16 MemoryInterface::DataRead(u16 address) {
     u16 value = shared_memory.ReadWord(converted);
     return value;
 }
-void MemoryInterface::DataWrite(u16 address, u16 value) {
-    if (memory_interface_unit.InMMIO(address)) {
+void MemoryInterface::DataWrite(u16 address, u16 value, bool bypass_mmio) {
+    if (memory_interface_unit.InMMIO(address) && !bypass_mmio) {
         ASSERT(mmio != nullptr);
         return mmio->Write(memory_interface_unit.ToMMIO(address), value);
     }
     u32 converted = memory_interface_unit.ConvertDataAddress(address);
     shared_memory.WriteWord(converted, value);
+}
+u16 MemoryInterface::DataReadA32(u32 address) const {
+    u32 converted = (address & ((MemoryInterfaceUnit::DataMemoryBankSize*2)-1))
+        + MemoryInterfaceUnit::DataMemoryOffset;
+    return shared_memory.ReadWord(converted);
+}
+void MemoryInterface::DataWriteA32(u32 address, u16 value) {
+    u32 converted = (address & ((MemoryInterfaceUnit::DataMemoryBankSize*2)-1))
+        + MemoryInterfaceUnit::DataMemoryOffset;
+    shared_memory.WriteWord(converted, value);
+}
+u16 MemoryInterface::MMIORead(u16 address) {
+    ASSERT(mmio != nullptr);
+    // according to GBATek ("DSi Teak I/O Ports (on ARM9 Side)"), these are mirrored
+    return mmio->Read(address & (MemoryInterfaceUnit::MMIOSize - 1));
+}
+void MemoryInterface::MMIOWrite(u16 address, u16 value) {
+    ASSERT(mmio != nullptr);
+    mmio->Write(address & (MemoryInterfaceUnit::MMIOSize - 1), value);
 }
 
 } // namespace Teakra

--- a/src/memory_interface.h
+++ b/src/memory_interface.h
@@ -28,7 +28,8 @@ public:
     }
     u16 ToMMIO(u16 addr) const {
         ASSERT(z_page == 0);
-        return addr - mmio_base;
+        // according to GBATek ("DSi Teak I/O Ports (on ARM9 Side)"), these are mirrored
+        return (addr - mmio_base) & (MMIOSize - 1);
     }
 
     u32 ConvertDataAddress(u16 addr) const {
@@ -56,8 +57,12 @@ public:
     void SetMMIO(MMIORegion& mmio);
     u16 ProgramRead(u32 address) const;
     void ProgramWrite(u32 address, u16 value);
-    u16 DataRead(u16 address); // not const because it can be a FIFO register
-    void DataWrite(u16 address, u16 value);
+    u16 DataRead(u16 address, bool bypass_mmio = false); // not const because it can be a FIFO register
+    void DataWrite(u16 address, u16 value, bool bypass_mmio = false);
+    u16 DataReadA32(u32 address) const;
+    void DataWriteA32(u32 address, u16 value);
+    u16 MMIORead(u16 address);
+    void MMIOWrite(u16 address, u16 value);
 
 private:
     SharedMemory& shared_memory;

--- a/src/teakra.cpp
+++ b/src/teakra.cpp
@@ -125,4 +125,44 @@ void Teakra::SetAudioCallback(std::function<void(std::array<s16, 2>)> callback) 
     impl->btdmp[0].SetAudioCallback(std::move(callback));
 }
 
+std::uint16_t Teakra::ProgramRead(std::uint32_t address) const {
+    return impl->memory_interface.ProgramRead(address);
+}
+void Teakra::ProgramWrite(std::uint32_t address, std::uint16_t value) {
+    impl->memory_interface.ProgramWrite(address, value);
+}
+std::uint16_t Teakra::DataRead(std::uint16_t address, bool bypass_mmio) {
+    return impl->memory_interface.DataRead(address, bypass_mmio);
+}
+void Teakra::DataWrite(std::uint16_t address, std::uint16_t value, bool bypass_mmio) {
+    impl->memory_interface.DataWrite(address, value, bypass_mmio);
+}
+std::uint16_t Teakra::DataReadA32(std::uint32_t address) const {
+    return impl->memory_interface.DataReadA32(address);
+}
+void Teakra::DataWriteA32(std::uint32_t address, std::uint16_t value) {
+    impl->memory_interface.DataWriteA32(address, value);
+}
+std::uint16_t Teakra::MMIORead(std::uint16_t address) {
+    return impl->memory_interface.MMIORead(address);
+}
+void Teakra::MMIOWrite(std::uint16_t address, std::uint16_t value) {
+    impl->memory_interface.MMIOWrite(address, value);
+}
+
+std::uint16_t Teakra::DMAChan0GetSrcHigh() {
+    u16 active_bak = impl->dma.GetActiveChannel();
+    impl->dma.ActivateChannel(0);
+    u16 ret = impl->dma.GetAddrSrcHigh();
+    impl->dma.ActivateChannel(active_bak);
+    return ret;
+}
+std::uint16_t Teakra::DMAChan0GetDstHigh() {
+    u16 active_bak = impl->dma.GetActiveChannel();
+    impl->dma.ActivateChannel(0);
+    u16 ret = impl->dma.GetAddrDstHigh();
+    impl->dma.ActivateChannel(active_bak);
+    return ret;
+}
+
 } // namespace Teakra

--- a/src/teakra_c.cpp
+++ b/src/teakra_c.cpp
@@ -66,6 +66,38 @@ uint16_t Teakra_GetSemaphore(const TeakraContext* context) {
     return context->teakra.GetSemaphore();
 }
 
+uint16_t Teakra_ProgramRead(TeakraContext* context, uint32_t address) {
+    return context->teakra.ProgramRead(address);
+}
+void Teakra_ProgramWrite(TeakraContext* context, uint32_t address, uint16_t value) {
+    context->teakra.ProgramWrite(address, value);
+}
+uint16_t Teakra_DataRead(TeakraContext* context, uint16_t address, bool bypass_mmio) {
+    return context->teakra.DataRead(address, bypass_mmio);
+}
+void Teakra_DataWrite(TeakraContext* context, uint16_t address, uint16_t value, bool bypass_mmio) {
+    context->teakra.DataWrite(address, value, bypass_mmio);
+}
+uint16_t Teakra_DataReadA32(TeakraContext* context, uint32_t address) {
+    return context->teakra.DataReadA32(address);
+}
+void Teakra_DataWriteA32(TeakraContext* context, uint32_t address, uint16_t value) {
+    context->teakra.DataWriteA32(address, value);
+}
+uint16_t Teakra_MMIORead(TeakraContext* context, uint16_t address) {
+    return context->teakra.MMIORead(address);
+}
+void Teakra_MMIOWrite(TeakraContext* context, uint16_t address, uint16_t value) {
+    context->teakra.MMIOWrite(address, value);
+}
+
+uint16_t Teakra_DMAChan0GetSrcHigh(TeakraContext* context) {
+    return context->teakra.DMAChan0GetSrcHigh();
+}
+uint16_t Teakra_DMAChan0GetDstHigh(TeakraContext* context){
+    return context->teakra.DMAChan0GetDstHigh();
+}
+
 void Teakra_Run(TeakraContext* context, unsigned cycle) {
     context->teakra.Run(cycle);
 }


### PR DESCRIPTION
More stuff melonDS needs, see [here](https://gitlab.ulyssis.org/pcy/melonDS/-/blob/d19962c4e7ea806a07f5e298fdda0e8cdb743793/src/DSi_DSP.cpp#L204-248) for example usage.