### PR TITLE
Disable -Werror=maybe-uninitialized

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ else()
         -pedantic
         -pedantic-errors
         -Wfatal-errors
+        -Wno-error=maybe-uninitialized
         -Wno-missing-braces
         -Wno-unused-parameter)
 


### PR DESCRIPTION
## Fixes

#51 

## Why?

GCC12 has made `-Werror=maybe-uninitialized` a default, it is too aggressive which leads to code error