### PR TITLE
Fix build failing with -Werror=no-ignored-attributes

### DIFF
--- a/src/mod_test_generator/main.cpp
+++ b/src/mod_test_generator/main.cpp
@@ -9,7 +9,7 @@ int main(int argc, char** argv) {
         return -1;
     }
 
-    std::unique_ptr<std::FILE, decltype(&std::fclose)> f{std::fopen(argv[1], "wb"), std::fclose};
+    std::unique_ptr<std::FILE, fclose_deleter> f{std::fopen(argv[1], "wb")};
     if (!f) {
         std::fprintf(stderr, "Unable to open file %s. Exiting...\n", argv[1]);
         return -2;

--- a/src/step2_test_generator/main.cpp
+++ b/src/step2_test_generator/main.cpp
@@ -8,7 +8,7 @@ int main(int argc, char** argv) {
         return -1;
     }
 
-    std::unique_ptr<std::FILE, decltype(&std::fclose)> f{std::fopen(argv[1], "wb"), std::fclose};
+    std::unique_ptr<std::FILE, fclose_deleter> f{std::fopen(argv[1], "wb")};
     if (!f) {
         std::fprintf(stderr, "Unable to open file %s. Exiting...\n", argv[1]);
         return -2;

--- a/src/test.h
+++ b/src/test.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstdio>
 #include <type_traits>
 
 #ifndef COMMON_TYPE_3DS
@@ -36,3 +37,9 @@ struct TestCase {
 
 static_assert(sizeof(TestCase) == 4312);
 static_assert(std::is_trivially_copyable_v<TestCase>);
+
+struct fclose_deleter {
+    void operator()(std::FILE* f) const {
+        std::fclose(f);
+    }
+};

--- a/src/test_generator.cpp
+++ b/src/test_generator.cpp
@@ -1440,7 +1440,7 @@ public:
 } // Anonymous namespace
 
 bool GenerateTestCasesToFile(const char* path) {
-    std::unique_ptr<std::FILE, decltype(&std::fclose)> f{std::fopen(path, "wb"), std::fclose};
+    std::unique_ptr<std::FILE, fclose_deleter> f{std::fopen(path, "wb")};
     if (!f) {
         return false;
     }

--- a/src/test_verifier/main.cpp
+++ b/src/test_verifier/main.cpp
@@ -24,7 +24,7 @@ int main(int argc, char** argv) {
         return -1;
     }
 
-    std::unique_ptr<std::FILE, decltype(&std::fclose)> file{std::fopen(argv[1], "rb"), std::fclose};
+    std::unique_ptr<std::FILE, fclose_deleter> file{std::fopen(argv[1], "rb")};
     if (!file) {
         std::fprintf(stderr, "Unable to open file %s. Exiting...\n", argv[1]);
         return -2;


### PR DESCRIPTION
Recent versions of GCC started throwing a no-ignored-attributes warning for code using `std::unique_ptr<std::FILE, decltype(std::fclose)>`, since some attribute set on fclose gets discarded.

To fix the issue, I've added a simple fclose_deleter callable which calls fclose. It also simplifies code as it is no longer needed to pass `std::fclose` as an argument when constructing the unique_ptr. Also, according to <https://stackoverflow.com/a/76867913/10767647>, this is "better practice".