### PR TITLE
Small CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.14)
 project(teakra CXX)
 
 # Determine if we're built as a subproject (using add_subdirectory)
@@ -7,6 +7,9 @@ set(MASTER_PROJECT OFF)
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(MASTER_PROJECT ON)
 endif()
+
+# Useful built-in modules
+include(GNUInstallDirs)
 
 option(TEAKRA_WARNINGS_AS_ERRORS "Warnings as errors" ${MASTER_PROJECT})
 option(TEAKRA_BUILD_TOOLS "Build tools" ${MASTER_PROJECT})
@@ -88,3 +91,16 @@ add_subdirectory(src)
 if (TEAKRA_BUILD_UNIT_TESTS)
   add_subdirectory(tests)
 endif()
+
+# Installation
+install(TARGETS teakra teakra_c EXPORT teakraTargets)
+install(EXPORT teakraTargets
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/teakra"
+    NAMESPACE "${PROJECT_NAME}"
+    FILE "teakraConfig.cmake"
+)
+
+install(DIRECTORY
+    "include/teakra"
+    TYPE INCLUDE
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,13 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 endif()
 
 # Useful built-in modules
+include(CMakeDependentOption)
+include(CTest)
 include(GNUInstallDirs)
 
 option(TEAKRA_WARNINGS_AS_ERRORS "Warnings as errors" ${MASTER_PROJECT})
 option(TEAKRA_BUILD_TOOLS "Build tools" ${MASTER_PROJECT})
-option(TEAKRA_BUILD_UNIT_TESTS "Build unit tests" ${MASTER_PROJECT})
+cmake_dependent_option(TEAKRA_BUILD_UNIT_TESTS "Build unit tests" "${MASTER_PROJECT}" "BUILD_TESTING" OFF)
 option(TEAKRA_RUN_TESTS "Run Teakra accuracy tests" OFF)
 
 # Set hard requirements for C++
@@ -74,8 +76,6 @@ endif()
 # Prefer the -pthread flag on Linux.
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
-
-enable_testing()
 
 if (NOT TEAKRA_TEST_ASSETS_DIR)
   set(TEAKRA_TEST_ASSETS_DIR "${CMAKE_CURRENT_BINARY_DIR}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,7 +41,9 @@ create_target_directory_groups(teakra)
 
 target_link_libraries(teakra PRIVATE Threads::Threads)
 target_include_directories(teakra
-                           PUBLIC ../include
+                           PUBLIC
+                            "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
+                            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
                            PRIVATE .)
 target_compile_options(teakra PRIVATE ${TEAKRA_CXX_FLAGS})
 
@@ -52,6 +54,8 @@ add_library(teakra_c
     teakra_c.cpp
 )
 target_link_libraries(teakra_c PRIVATE teakra)
+
+set_target_properties(teakra teakra_c PROPERTIES VERSION 0)
 
 if (TEAKRA_BUILD_TOOLS)
     add_subdirectory(coff_reader)


### PR DESCRIPTION
Hi!

In this patch set I've made some small improvements to the CMake build system: it now supports installing the project, and skipping tests by using the standard `BUILD_TESTING` option.

I'm making these changes as they are required to package Teakra in Debian; it is used by various DS/3DS emulators, and packaging this project is a prerequisite to packaging those emulators too.

I've detailed my changes in the two commit messages, but for your convenience I'll include them here.

### Add install target to CMake

This allows system-wide installation, useful for distribution packagers.

The minimum required CMake version is bumped to 3.14, as the `TYPE` argument of `install(DIRECTORY)` requires it. This also has the benefit of fixing the CMake 3.10 deprecation warning.

### Support BUILD_TESTING CMake option

The `BUILD_TESTING` option is the standard CMake option used to disable tests.

With this patch, tests will only be built when `BUILD_TESTING` isn't `OFF`.

In other words, defining `BUILD_TESTING=OFF` will disable tests, regardless of the value of `MASTER_PROJECT` and `TEAKRA_BUILD_UNIT_TESTS`. It ovverides them.

When the user does not explicitly define `BUILD_TESTING=OFF`, the build will behave as before.

The `BUILD_TESTING` option is defined by the built-in `CTest` module.  Including the module also automatically calls `enable_testing()`, so calling it explicitly isn't required anymore.

Honouring this option is especially nice for downstream distributions like Debian, as our build systems automatically define `BUILD_TESTING=OFF` when appropriate.