### PR TITLE
Processor: Expose register struct in C++ interface

### DIFF
--- a/include/teakra/impl/register.h
+++ b/include/teakra/impl/register.h
@@ -4,9 +4,9 @@
 #include <array>
 #include <memory>
 #include <vector>
-#include "common_types.h"
-#include "crash.h"
-#include "operand.h"
+#include "../../../src/common_types.h"
+#include "../../../src/crash.h"
+#include "../../../src/operand.h"
 
 namespace Teakra {
 
@@ -167,7 +167,7 @@ struct RegisterState {
 
     /** Shadow registers **/
 
-    template <u16 RegisterState::*origin>
+    template <u16 RegisterState::* origin>
     class ShadowRegister {
     public:
         void Store(RegisterState* self) {
@@ -181,7 +181,7 @@ struct RegisterState {
         u16 shadow = 0;
     };
 
-    template <std::size_t size, std::array<u16, size> RegisterState::*origin>
+    template <std::size_t size, std::array<u16, size> RegisterState::* origin>
     class ShadowArrayRegister {
     public:
         void Store(RegisterState* self) {
@@ -206,7 +206,7 @@ struct RegisterState {
         }
     };
 
-    template <u16 RegisterState::*origin>
+    template <u16 RegisterState::* origin>
     class ShadowSwapRegister {
     public:
         void Swap(RegisterState* self) {
@@ -217,7 +217,7 @@ struct RegisterState {
         u16 shadow = 0;
     };
 
-    template <std::size_t size, std::array<u16, size> RegisterState::*origin>
+    template <std::size_t size, std::array<u16, size> RegisterState::* origin>
     class ShadowSwapArrayRegister {
     public:
         void Swap(RegisterState* self) {
@@ -410,7 +410,7 @@ struct RegisterState {
     }
 };
 
-template <u16 RegisterState::*target>
+template <u16 RegisterState::* target>
 struct Redirector {
     static u16 Get(const RegisterState* self) {
         return self->*target;
@@ -420,7 +420,7 @@ struct Redirector {
     }
 };
 
-template <std::size_t size, std::array<u16, size> RegisterState::*target, std::size_t index>
+template <std::size_t size, std::array<u16, size> RegisterState::* target, std::size_t index>
 struct ArrayRedirector {
     static u16 Get(const RegisterState* self) {
         return (self->*target)[index];
@@ -430,7 +430,7 @@ struct ArrayRedirector {
     }
 };
 
-template <u16 RegisterState::*target0, u16 RegisterState::*target1>
+template <u16 RegisterState::* target0, u16 RegisterState::* target1>
 struct DoubleRedirector {
     static u16 Get(const RegisterState* self) {
         return self->*target0 | self->*target1;
@@ -440,7 +440,7 @@ struct DoubleRedirector {
     }
 };
 
-template <u16 RegisterState::*target>
+template <u16 RegisterState::* target>
 struct RORedirector {
     static u16 Get(const RegisterState* self) {
         return self->*target;
@@ -450,7 +450,7 @@ struct RORedirector {
     }
 };
 
-template <std::size_t size, std::array<u16, size> RegisterState::*target, std::size_t index>
+template <std::size_t size, std::array<u16, size> RegisterState::* target, std::size_t index>
 struct ArrayRORedirector {
     static u16 Get(const RegisterState* self) {
         return (self->*target)[index];

--- a/include/teakra/teakra.h
+++ b/include/teakra/teakra.h
@@ -6,6 +6,7 @@
 #include <memory>
 
 namespace Teakra {
+struct RegisterState;
 
 struct AHBMCallback {
     std::function<std::uint8_t(std::uint32_t address)> read8;
@@ -27,6 +28,9 @@ public:
 
     std::array<std::uint8_t, 0x80000>& GetDspMemory();
     const std::array<std::uint8_t, 0x80000>& GetDspMemory() const;
+
+    RegisterState& GetRegisterState();
+    const RegisterState& GetRegisterState() const;
 
     // APBP Data
     bool SendDataIsEmpty(std::uint8_t index) const;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ include(CreateDirectoryGroups)
 add_library(teakra
     ../include/teakra/disassembler.h
     ../include/teakra/teakra.h
+    ../include/teakra/impl/register.h
     ahbm.cpp
     ahbm.h
     apbp.cpp
@@ -29,7 +30,6 @@ add_library(teakra
     parser.cpp
     processor.cpp
     processor.h
-    register.h
     shared_memory.h
     teakra.cpp
     test.h
@@ -44,7 +44,7 @@ target_include_directories(teakra
                            PUBLIC
                             "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
                             "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-                           PRIVATE .)
+                           PRIVATE . ../include/teakra/impl)
 target_compile_options(teakra PRIVATE ${TEAKRA_CXX_FLAGS})
 
 add_library(teakra_c

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -1,11 +1,11 @@
 #pragma once
-#include <utility>
 #include <atomic>
 #include <stdexcept>
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include "bit.h"
 #include "core_timing.h"
 #include "crash.h"

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -31,4 +31,12 @@ void Processor::SignalVectoredInterrupt(u32 address, bool context_switch) {
     impl->interpreter.SignalVectoredInterrupt(address, context_switch);
 }
 
+Teakra::RegisterState& Processor::GetRegisterState() {
+    return impl->regs;
+}
+
+const Teakra::RegisterState& Processor::GetRegisterState() const {
+    return impl->regs;
+}
+
 } // namespace Teakra

--- a/src/processor.h
+++ b/src/processor.h
@@ -7,6 +7,7 @@
 namespace Teakra {
 
 class MemoryInterface;
+struct RegisterState;
 
 class Processor {
 public:
@@ -16,6 +17,9 @@ public:
     void Run(unsigned cycles);
     void SignalInterrupt(u32 i);
     void SignalVectoredInterrupt(u32 address, bool context_switch);
+
+    RegisterState& GetRegisterState();
+    const RegisterState& GetRegisterState() const;
 
 private:
     struct Impl;

--- a/src/teakra.cpp
+++ b/src/teakra.cpp
@@ -9,6 +9,7 @@
 #include "memory_interface.h"
 #include "mmio.h"
 #include "processor.h"
+#include "register.h"
 #include "shared_memory.h"
 #include "teakra/teakra.h"
 #include "timer.h"
@@ -79,6 +80,14 @@ const std::array<std::uint8_t, 0x80000>& Teakra::GetDspMemory() const {
     return impl->shared_memory.raw;
 }
 
+RegisterState& Teakra::GetRegisterState() {
+    return impl->processor.GetRegisterState();
+}
+
+const RegisterState& Teakra::GetRegisterState() const {
+    return impl->processor.GetRegisterState();
+}
+
 void Teakra::Run(unsigned cycle) {
     impl->processor.Run(cycle);
 }
@@ -118,9 +127,8 @@ void Teakra::MaskSemaphore(std::uint16_t value) {
     impl->apbp_from_dsp.MaskSemaphore(value);
 }
 void Teakra::SetAHBMCallback(const AHBMCallback& callback) {
-    impl->ahbm.SetExternalMemoryCallback(callback.read8, callback.write8,
-        callback.read16, callback.write16,
-        callback.read32, callback.write32);
+    impl->ahbm.SetExternalMemoryCallback(callback.read8, callback.write8, callback.read16,
+                                         callback.write16, callback.read32, callback.write32);
 }
 
 std::uint16_t Teakra::AHBMGetUnitSize(std::uint16_t i) const {


### PR DESCRIPTION
Continuing from #59 
There's some minor unrelated formatting changes, those are just clang-format automatically formatting based on the .clang-format in the repo though.