### PR TITLE
Allow Teakra to either own DSP memory or have the user provide their own

### DIFF
--- a/include/teakra/teakra.h
+++ b/include/teakra/teakra.h
@@ -20,7 +20,9 @@ struct AHBMCallback {
 };
 
 struct UserConfig {
-    std::uint8_t* dsp_memory;
+    // DSP memory. By default set to nullptr. If it stays nullptr then Teakra will create its own
+    // DSP memory and retain ownership of it. Otherwise, the user will own it.
+    std::uint8_t* dsp_memory = nullptr;
 };
 
 static constexpr std::uint32_t DspMemorySize = 0x80000;

--- a/include/teakra/teakra.h
+++ b/include/teakra/teakra.h
@@ -19,15 +19,21 @@ struct AHBMCallback {
     std::function<void(std::uint32_t address, std::uint32_t value)> write32;
 };
 
+struct UserConfig {
+    std::uint8_t* dsp_memory;
+};
+
+static constexpr std::uint32_t DspMemorySize = 0x80000;
+
 class Teakra {
 public:
-    Teakra();
+    Teakra(const UserConfig& config);
     ~Teakra();
 
     void Reset();
 
-    std::array<std::uint8_t, 0x80000>& GetDspMemory();
-    const std::array<std::uint8_t, 0x80000>& GetDspMemory() const;
+    uint8_t* GetDspMemory();
+    const uint8_t* GetDspMemory() const;
 
     RegisterState& GetRegisterState();
     const RegisterState& GetRegisterState() const;

--- a/src/shared_memory.h
+++ b/src/shared_memory.h
@@ -1,11 +1,13 @@
 #pragma once
-#include <array>
-#include <cstdio>
+
 #include "common_types.h"
 
 namespace Teakra {
 struct SharedMemory {
-    std::array<u8, 0x80000> raw{};
+    u8* raw;
+
+    SharedMemory(u8* mem) : raw{mem} {}
+
     u16 ReadWord(u32 word_address) const {
         u32 byte_address = word_address * 2;
         u8 low = raw[byte_address];

--- a/src/shared_memory.h
+++ b/src/shared_memory.h
@@ -1,24 +1,20 @@
 #pragma once
-
+#include <array>
+#include <memory>
+#include <optional>
 #include "common_types.h"
 
 namespace Teakra {
 struct SharedMemory {
+    // We allocate our own memory if the user doesn't supply their own
+    std::unique_ptr<std::array<u8, 0x80000>> own_memory;
+    // Points to either own own memory or user-supplied memory
     u8* raw;
-    bool own_dsp_mem;
 
     SharedMemory(u8* mem = nullptr) : raw{mem} {
         if (mem == nullptr) {
-            raw = new uint8_t[0x80000];
-            own_dsp_mem = true;
-        } else {
-            own_dsp_mem = false;
-        }
-    }
-
-    ~SharedMemory() {
-        if (own_dsp_mem) {
-            delete[] raw;
+            own_memory = std::make_unique<std::array<u8, 0x80000>>();
+            raw = own_memory->data();
         }
     }
 

--- a/src/shared_memory.h
+++ b/src/shared_memory.h
@@ -5,8 +5,22 @@
 namespace Teakra {
 struct SharedMemory {
     u8* raw;
+    bool own_dsp_mem;
 
-    SharedMemory(u8* mem) : raw{mem} {}
+    SharedMemory(u8* mem = nullptr) : raw{mem} {
+        if (mem == nullptr) {
+            raw = new uint8_t[0x80000];
+            own_dsp_mem = true;
+        } else {
+            own_dsp_mem = false;
+        }
+    }
+
+    ~SharedMemory() {
+        if (own_dsp_mem) {
+            delete[] raw;
+        }
+    }
 
     u16 ReadWord(u32 word_address) const {
         u32 byte_address = word_address * 2;

--- a/src/teakra_c.cpp
+++ b/src/teakra_c.cpp
@@ -4,7 +4,8 @@
 extern "C" {
 
 struct TeakraObject {
-    Teakra::Teakra teakra;
+    Teakra::UserConfig config;
+    Teakra::Teakra teakra{config};
 };
 
 TeakraContext* Teakra_Create() {
@@ -17,10 +18,6 @@ void Teakra_Destroy(TeakraContext* context) {
 
 void Teakra_Reset(TeakraContext* context) {
     context->teakra.Reset();
-}
-
-uint8_t* Teakra_GetDspMemory(TeakraContext* context) {
-    return context->teakra.GetDspMemory().data();
 }
 
 int Teakra_SendDataIsEmpty(const TeakraContext* context, uint8_t index) {

--- a/src/teakra_c.cpp
+++ b/src/teakra_c.cpp
@@ -20,6 +20,10 @@ void Teakra_Reset(TeakraContext* context) {
     context->teakra.Reset();
 }
 
+uint8_t* Teakra_GetDspMemory(TeakraContext* context) {
+    return context->teakra.GetDspMemory();
+}
+
 int Teakra_SendDataIsEmpty(const TeakraContext* context, uint8_t index) {
     return context->teakra.SendDataIsEmpty(index);
 }
@@ -91,7 +95,7 @@ void Teakra_MMIOWrite(TeakraContext* context, uint16_t address, uint16_t value) 
 uint16_t Teakra_DMAChan0GetSrcHigh(TeakraContext* context) {
     return context->teakra.DMAChan0GetSrcHigh();
 }
-uint16_t Teakra_DMAChan0GetDstHigh(TeakraContext* context){
+uint16_t Teakra_DMAChan0GetDstHigh(TeakraContext* context) {
     return context->teakra.DMAChan0GetDstHigh();
 }
 
@@ -122,11 +126,10 @@ void Teakra_Run(TeakraContext* context, unsigned cycle) {
     context->teakra.Run(cycle);
 }
 
-void Teakra_SetAHBMCallback(TeakraContext* context,
-                            Teakra_AHBMReadCallback8  read8 , Teakra_AHBMWriteCallback8  write8 ,
-                            Teakra_AHBMReadCallback16 read16, Teakra_AHBMWriteCallback16 write16,
-                            Teakra_AHBMReadCallback32 read32, Teakra_AHBMWriteCallback32 write32,
-                            void* userdata) {
+void Teakra_SetAHBMCallback(TeakraContext* context, Teakra_AHBMReadCallback8 read8,
+                            Teakra_AHBMWriteCallback8 write8, Teakra_AHBMReadCallback16 read16,
+                            Teakra_AHBMWriteCallback16 write16, Teakra_AHBMReadCallback32 read32,
+                            Teakra_AHBMWriteCallback32 write32, void* userdata) {
     Teakra::AHBMCallback callback;
     callback.read8 = [=](uint32_t address) { return read8(userdata, address); };
     callback.write8 = [=](uint32_t address, uint8_t value) { write8(userdata, address, value); };
@@ -136,7 +139,6 @@ void Teakra_SetAHBMCallback(TeakraContext* context,
     callback.write32 = [=](uint32_t address, uint32_t value) { write32(userdata, address, value); };
     context->teakra.SetAHBMCallback(callback);
 }
-
 
 void Teakra_SetAudioCallback(TeakraContext* context, Teakra_AudioCallback callback,
                              void* userdata) {

--- a/tests/dma.cpp
+++ b/tests/dma.cpp
@@ -33,13 +33,14 @@ TEST_CASE("DMA + AHBM test", "[dma]") {
         },
         [&fcram](u32 address) -> u32 {
             REQUIRE(address >= 0x20000000);
-            return fcram[address - 0x20000000] | ((u32)fcram[address - 0x20000000 + 1] << 8)
-                | ((u32)fcram[address - 0x20000000 + 2] << 16) | ((u32)fcram[address - 0x20000000 + 3] << 24);
+            return fcram[address - 0x20000000] | ((u32)fcram[address - 0x20000000 + 1] << 8) |
+                   ((u32)fcram[address - 0x20000000 + 2] << 16) |
+                   ((u32)fcram[address - 0x20000000 + 3] << 24);
         },
         [&fcram](u32 address, u32 v) {
             REQUIRE(address >= 0x20000000);
             fcram[address - 0x20000000 + 0] = (u8)v;
-            fcram[address - 0x20000000 + 1] = (u8)(v >>  8);
+            fcram[address - 0x20000000 + 1] = (u8)(v >> 8);
             fcram[address - 0x20000000 + 2] = (u8)(v >> 16);
             fcram[address - 0x20000000 + 3] = (u8)(v >> 24);
         });
@@ -50,8 +51,7 @@ TEST_CASE("DMA + AHBM test", "[dma]") {
     }
 
     auto GetDspTestArea = [&shared_memory]() {
-        return std::vector<u8>(shared_memory.raw.begin() + 0x40000,
-                               shared_memory.raw.begin() + 0x40000 + 0x80);
+        return std::vector<u8>(shared_memory.raw + 0x40000, shared_memory.raw + 0x40000 + 0x80);
     };
 
     auto GenerateExpected = [](const std::string& str, u8 base = 0) {


### PR DESCRIPTION
Continuing from https://github.com/wwylele/teakra/issues/55

As the title says, this PR lets the user supply their own DSP memory if needed, for purposes such as implementing fastmem, using host shared memory for exposing DSP RAM to other processing, applying memory protections to DSP memory, and so on.

This is done via a UserConfig object via which the user passes to Teakra. This config object will also be needed when it's time to merge the Teak JIT from https://github.com/raphaelthegreat/teakra/ (for enabling/disabling the JIT), which is probably not going to be any time soon as it needs a hefty rewrite.

One minor caveat is that this UserConfig struct hasn't been ported to the C interface yet, and they behave the same as they did before this PR (ie always owning DSP memory). The reason for this is that I'm unsure how to port the struct in the longterm without duplicating a lot of code (by eg making a C version of the struct, and having the interface's cpp file copy each field to the C++ version). Regardless, this isn't a huge problem since the C interface isn't as widely used, and users likely don't care much about this in the first place. It will be more important to implement C interface configs when the JIT is ready.

Tested locally by integrating the changes to Panda3DS, running the test verifier, and by testing the Rust bindings to see that the C interface still works fine.